### PR TITLE
Add git hook to check for formatting

### DIFF
--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./git_hooks/rustfmt.sh || exit $?

--- a/git_hooks/rustfmt.sh
+++ b/git_hooks/rustfmt.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Shamelessly stolen from https://eugene-babichenko.github.io/blog/2018/11/08/rustfmt-git-hook/
+
+HAS_ISSUES=0
+
+for file in $(git diff --name-only --staged --diff-filter=d); do
+	# This sucks but rustfmt doesn't allow --check with stdin because ???? idfk
+	if [[ "$file" =~ '.rs'$ ]]; then
+		FMT_RESULT=$(diff <(git show ":$file") <(git show ":$file" | rustfmt))
+		if [ "$FMT_RESULT" != "" ]; then
+			echo "$file"
+			HAS_ISSUES=1
+		fi
+	fi
+done
+
+if [ $HAS_ISSUES -eq 0 ]; then
+    exit 0
+fi
+
+echo "Your code has formatting issues in the files listed above."
+echo "Run \`cargo fmt\` and stage the changes."
+exit 1
+

--- a/git_hooks/setup.sh
+++ b/git_hooks/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -rf ../.git/hooks
+ln -s ../git_hooks ../.git/hooks


### PR DESCRIPTION
This could be useful to avoid merge conflicts due to formatting
differences between editors.